### PR TITLE
fix(zsh): resolve brew command-not-found handler error

### DIFF
--- a/zsh/.zsh_aliases
+++ b/zsh/.zsh_aliases
@@ -16,3 +16,15 @@ alias kns='kubectl config set-context --current --namespace'
 # Misc
 alias reload='exec zsh'
 alias stow='stow -v'
+
+# Workaround for Homebrew command-not-found handler bug
+# `brew which-formula` no longer accepts `--skip-update` but `handler.sh` still passes it.
+brew() {
+  if [[ "$1" == "which-formula" && "$2" == "--skip-update" ]]; then
+    shift 2
+    command brew which-formula "$@"
+  else
+    command brew "$@"
+  fi
+}
+


### PR DESCRIPTION
## Description
Upstream Homebrew recently removed the `--skip-update` flag from `brew which-formula` but missed updating `command-not-found/handler.sh`. This results in the shell outputting a `brew which-formula` usage error instead of suggesting the correct formula when an unknown command is invoked.

## Solution
Added a temporary wrapper function for `brew` in `zsh/.zsh_aliases` that intercepts `brew which-formula --skip-update` and calls it without the obsolete flag. This restores the command-not-found behavior.

## Test Plan
1. Open a new zsh session.
2. Run an unavailable command (e.g., `pdflatex`).
3. Verify that it suggests the Homebrew package (e.g., `texlive`) instead of printing the usage error.