### PR TITLE
feat(zellij): stack rca and simulator panes in sbk tab

### DIFF
--- a/zellij/.config/zellij/layouts/main.kdl
+++ b/zellij/.config/zellij/layouts/main.kdl
@@ -24,9 +24,9 @@ layout {
             pane command="zsh" name="inspector" size="50%" {
                 args "-c" "export KUBECONFIG=$HOME/.sim/admin.kubeconfig; zsh"
             }
-            pane size="50%" {
-                pane name="rca" cwd="Downloads" size="70%"
-                pane name="simulator" cwd="/tmp" size="30%"
+            pane size="50%" stacked=true {
+                pane name="rca" cwd="Downloads"
+                pane name="simulator" cwd="/tmp"
             }
         }
         pane size=1 borderless=true {


### PR DESCRIPTION
## Summary

Stack the `rca` and `simulator` panes inside the `sbk` Zellij tab so only one pane is expanded at a time, with the other collapsed to a single-line header.

## Changes

- Added `stacked=true` to the right-side container pane of `sbk`'s vertical split.
- Removed the now-irrelevant per-pane `size` attributes (`70%`/`30%`) from `rca` and `simulator`, since stacked mode expands the focused pane to the full column height.

## Layout (before/after)

**Before:** `rca` (70%) and `simulator` (30%) stacked vertically as fixed splits.

**After:** `rca` and `simulator` in a stacked layout — the focused pane fills the right column; the other collapses to a header bar.